### PR TITLE
fix: pass JsonSerialize encoder to simplejson.dumps in JSONL format writer

### DIFF
--- a/target_s3/formats/format_jsonl.py
+++ b/target_s3/formats/format_jsonl.py
@@ -26,7 +26,7 @@ class FormatJsonl(FormatBase):
         return super()._prepare_records()
 
     def _write(self) -> None:
-        return super()._write('\n'.join(map(dumps, self.records)))
+        return super()._write('\n'.join(dumps(r, cls=JsonSerialize) for r in self.records))
 
     def run(self) -> None:
         # use default behavior, no additional run steps needed


### PR DESCRIPTION
The FormatJsonl class defines a JsonSerialize encoder that correctly converts datetime objects to ISO 8601 strings via `isoformat()`, but the` _write` method was calling `simplejson.dumps` without passing `cls=JsonSerialize`. This caused a `TypeError ("Object of type datetime is not JSON serializable")` whenever a Singer tap emitted records containing date-time formatted fields that the Singer SDK had already parsed into Python datetime objects.